### PR TITLE
Improve doctrine types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- When scalar values (`string`, `int`, `float` or `bool`) are provided to a doctrine type, then they are piped through without trying to normalize them.
+
 ## 0.1.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 A Symfony bundle to enable value objects and DTOs to normalize and denormalize themselves through implementing simple interfaces that normalize to scalar values and denormalize themselves from scalar values (`string`, `int`, `float`, `bool` and `array`). Adding this kind of logic to the classes themselves might be considered a bad practice, but depending on the use case it will actually be better due to the fact that the data structure and the normalization need to be changed together.
 
+The name implies that the value objects and DTOs are self-aware in the sense that they know how to normalize and denormalize themselves and that they are self-aware enough to do so 🙂 
+
 As it's a central part of an application, it's tested thoroughly (including mutation testing).
 
-[![Latest Stable Version](https://img.shields.io/badge/stable-0.1.0-blue)](https://packagist.org/packages/digital-craftsman/self-aware-normalizers)
+[![Latest Stable Version](https://img.shields.io/badge/stable-0.2.0-blue)](https://packagist.org/packages/digital-craftsman/self-aware-normalizers)
 [![PHP Version Require](https://img.shields.io/badge/php-8.3|8.4-5b5d95)](https://packagist.org/packages/digital-craftsman/self-aware-normalizers)
 [![codecov](https://codecov.io/gh/digital-craftsman-de/self-aware-normalizers/branch/main/graph/badge.svg?token=BL0JKZYLBG)](https://codecov.io/gh/digital-craftsman-de/self-aware-normalizers)
 ![Packagist Downloads](https://img.shields.io/packagist/dt/digital-craftsman/self-aware-normalizers)
@@ -18,7 +20,7 @@ Install package through composer:
 composer require digital-craftsman/self-aware-normalizers
 ```
 
-> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/self-aware-normalizers:0.1.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
+> ⚠️ This bundle can be used (and is being used) in production, but hasn't reached version 1.0 yet. Therefore, there will be breaking changes between minor versions. I'd recommend that you require the bundle only with the current minor version like `composer require digital-craftsman/self-aware-normalizers:0.2.*`. Breaking changes are described in the releases and [the changelog](./CHANGELOG.md). Updates are described in the [upgrade guide](./UPGRADE.md).
 
 ## Usage
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,5 @@
 # Upgrade guide
 
-No upgrade yet.
+## From 0.1.* to 0.2.0
+
+Nothing to do.

--- a/src/Doctrine/BoolNormalizableType.php
+++ b/src/Doctrine/BoolNormalizableType.php
@@ -43,13 +43,17 @@ abstract class BoolNormalizableType extends Type
     }
 
     /**
-     * @param ?BoolNormalizable $value
+     * @param BoolNormalizable|bool|null $value
      */
     #[\Override]
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?bool
     {
         if ($value === null) {
             return null;
+        }
+
+        if (is_bool($value)) {
+            return $value;
         }
 
         return $value->normalize();

--- a/src/Doctrine/FloatNormalizableType.php
+++ b/src/Doctrine/FloatNormalizableType.php
@@ -45,13 +45,17 @@ abstract class FloatNormalizableType extends Type
     }
 
     /**
-     * @param ?FloatNormalizable $value
+     * @param FloatNormalizable|float|null $value
      */
     #[\Override]
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?float
     {
         if ($value === null) {
             return null;
+        }
+
+        if (is_float($value)) {
+            return $value;
         }
 
         return $value->normalize();

--- a/src/Doctrine/IntNormalizableType.php
+++ b/src/Doctrine/IntNormalizableType.php
@@ -43,13 +43,17 @@ abstract class IntNormalizableType extends Type
     }
 
     /**
-     * @param ?IntNormalizable $value
+     * @param IntNormalizable|int|null $value
      */
     #[\Override]
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?int
     {
         if ($value === null) {
             return null;
+        }
+
+        if (is_int($value)) {
+            return $value;
         }
 
         return $value->normalize();

--- a/src/Doctrine/StringNormalizableType.php
+++ b/src/Doctrine/StringNormalizableType.php
@@ -51,13 +51,17 @@ abstract class StringNormalizableType extends Type
     }
 
     /**
-     * @param ?StringNormalizable $value
+     * @param StringNormalizable|string|null $value
      */
     #[\Override]
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
             return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
         }
 
         return $value->normalize();

--- a/tests/Doctrine/BoolNormalizableTypeTest.php
+++ b/tests/Doctrine/BoolNormalizableTypeTest.php
@@ -47,4 +47,20 @@ final class BoolNormalizableTypeTest extends TestCase
         // -- Assert
         self::assertEquals($value, $convertedValue);
     }
+
+    #[Test]
+    public function convert_to_database_value_works_with_bool(): void
+    {
+        // -- Arrange
+        $doctrineType = new AcceptedTermsOfServiceType();
+        $platform = new PostgreSQLPlatform();
+
+        $value = true;
+
+        // -- Act
+        $databaseValue = $doctrineType->convertToDatabaseValue($value, $platform);
+
+        // -- Assert
+        self::assertEquals($value, $databaseValue);
+    }
 }

--- a/tests/Doctrine/FloatNormalizableTypeTest.php
+++ b/tests/Doctrine/FloatNormalizableTypeTest.php
@@ -49,4 +49,20 @@ final class FloatNormalizableTypeTest extends TestCase
         // -- Assert
         self::assertEquals($value, $convertedValue);
     }
+
+    #[Test]
+    public function convert_to_database_value_works_with_float(): void
+    {
+        // -- Arrange
+        $doctrineType = new RangeType();
+        $platform = new PostgreSQLPlatform();
+
+        $value = 0.5;
+
+        // -- Act
+        $databaseValue = $doctrineType->convertToDatabaseValue($value, $platform);
+
+        // -- Assert
+        self::assertEquals($value, $databaseValue);
+    }
 }

--- a/tests/Doctrine/IntNormalizableTypeTest.php
+++ b/tests/Doctrine/IntNormalizableTypeTest.php
@@ -47,4 +47,20 @@ final class IntNormalizableTypeTest extends TestCase
         // -- Assert
         self::assertEquals($value, $convertedValue);
     }
+
+    #[Test]
+    public function convert_to_database_value_works_with_int(): void
+    {
+        // -- Arrange
+        $doctrineType = new LimitType();
+        $platform = new PostgreSQLPlatform();
+
+        $value = 60;
+
+        // -- Act
+        $databaseValue = $doctrineType->convertToDatabaseValue($value, $platform);
+
+        // -- Assert
+        self::assertEquals($value, $databaseValue);
+    }
 }

--- a/tests/Doctrine/StringNormalizableTypeTest.php
+++ b/tests/Doctrine/StringNormalizableTypeTest.php
@@ -32,6 +32,22 @@ final class StringNormalizableTypeTest extends TestCase
     }
 
     #[Test]
+    public function convert_to_database_value_works_with_string(): void
+    {
+        // -- Arrange
+        $doctrineType = new SearchTermType();
+        $platform = new PostgreSQLPlatform();
+
+        $value = 'peter';
+
+        // -- Act
+        $databaseValue = $doctrineType->convertToDatabaseValue($value, $platform);
+
+        // -- Assert
+        self::assertEquals($value, $databaseValue);
+    }
+
+    #[Test]
     public function convert_works_with_null(): void
     {
         // -- Arrange


### PR DESCRIPTION
## Changes

- When scalar values (`string`, `int`, `float` or `bool`) are provided to a doctrine type, then they are piped through without trying to normalize them.
- Prepare next release.